### PR TITLE
WEOS-957 Add middleware for writing response to file

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,153 @@
+package weoscontroller
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+//LoadHttpRequestFixture wrapper around the test helper to make it easier to use it with test table
+func LoadHttpRequestFixture(filename string) (*http.Request, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bufio.NewReader(bytes.NewReader(data))
+	request, err := http.ReadRequest(reader)
+	if err == io.EOF {
+		return request, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	actualRequest, err := http.NewRequest(request.Method, request.URL.String(), reader)
+	if err != nil {
+		return nil, err
+	}
+	return actualRequest, nil
+}
+
+//LoadHttpResponseFixture wrapper around the test helper to make it easier to use it with test table
+func LoadHttpResponseFixture(filename string, req *http.Request) (*http.Response, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(bytes.NewReader(data))
+	resp, err := http.ReadResponse(reader, req)
+	if err != nil {
+		return nil, err
+	}
+	//save response body
+	b := new(bytes.Buffer)
+	io.Copy(b, resp.Body)
+	resp.Body.Close()
+	resp.Body = ioutil.NopCloser(b)
+
+	return resp, err
+}
+
+// NewRespBodyFromBytes creates an io.ReadCloser from a byte slice that is suitable for use as an
+// http response body.
+func NewRespBodyFromBytes(body []byte) io.ReadCloser {
+	return &dummyReadCloser{bytes.NewReader(body)}
+}
+
+type dummyReadCloser struct {
+	body io.ReadSeeker
+}
+
+func (d *dummyReadCloser) Read(p []byte) (n int, err error) {
+	n, err = d.body.Read(p)
+	if err == io.EOF {
+		d.body.Seek(0, 0)
+	}
+	return n, err
+}
+
+func (d *dummyReadCloser) Close() error {
+	return nil
+}
+
+type multiWriter struct {
+	writers []http.ResponseWriter
+}
+
+func (t *multiWriter) Write(p []byte) (n int, err error) {
+	for _, w := range t.writers {
+		n, err = w.Write(p)
+		if err != nil {
+			return
+		}
+		if n != len(p) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(p), nil
+}
+
+func (t *multiWriter) Header() http.Header {
+	header := make(http.Header)
+	for _, w := range t.writers {
+		for k, v := range w.Header() {
+			for _, val := range v {
+				header.Add(k, val)
+			}
+		}
+	}
+	return header
+}
+
+func (t *multiWriter) WriteHeader(statusCode int) {
+	for _, w := range t.writers {
+		w.WriteHeader(statusCode)
+	}
+}
+
+var _ io.StringWriter = (*multiWriter)(nil)
+
+func (t *multiWriter) WriteString(s string) (n int, err error) {
+	var p []byte // lazily initialized if/when needed
+	for _, w := range t.writers {
+		if sw, ok := w.(io.StringWriter); ok {
+			n, err = sw.WriteString(s)
+		} else {
+			if p == nil {
+				p = []byte(s)
+			}
+			n, err = w.Write(p)
+		}
+		if err != nil {
+			return
+		}
+		if n != len(s) {
+			err = io.ErrShortWrite
+			return
+		}
+	}
+	return len(s), nil
+}
+
+// MultiWriter creates a writer that duplicates its writes to all the
+// provided writers, similar to the Unix tee(1) command.
+//
+// Each write is written to each listed writer, one at a time.
+// If a listed writer returns an error, that overall write operation
+// stops and returns the error; it does not continue down the list.
+func MultiWriter(writers ...http.ResponseWriter) http.ResponseWriter {
+	allWriters := make([]http.ResponseWriter, 0, len(writers))
+	for _, w := range writers {
+		if mw, ok := w.(*multiWriter); ok {
+			allWriters = append(allWriters, mw.writers...)
+		} else {
+			allWriters = append(allWriters, w)
+		}
+	}
+	return &multiWriter{allWriters}
+}


### PR DESCRIPTION
* Moved "LoadHtttpRequestFixture" to utils file so that they can be used by api (this would replace using the test helper package)

* Added a way to set multiple writers to the response. This is how we can test the ResponseRecording middleware since we can set a ResponseRecorder as a writer (in addition to the default writer)

* Added middleware for recording response to file

* Added method for loading response fixture (note it requires a request to be passed in)